### PR TITLE
remove STPPaymentMethodTypeFPX case to fix ios build

### DIFF
--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -126,7 +126,6 @@ RCT_ENUM_CONVERTER(STPPaymentMethodType,
         case STPPaymentMethodTypeCard: return @"card";
         case STPPaymentMethodTypeiDEAL: return @"iDEAL";
         case STPPaymentMethodTypeCardPresent: return @"card_present";
-        case STPPaymentMethodTypeFPX: return @"fpx";
         case STPPaymentMethodTypeUnknown:
         default: return @"unknown";
     }


### PR DESCRIPTION
Hey hoxfon,

I've been using your experimental branch for your RN 0.60+ support.

We started running into an error on the ios build:

Duplicate case value 'STPPaymentMethodTypeCard'
Use of undeclared identifier 'STPPaymentMethodTypeFPX'; did you mean 'STPPaymentMethodTypeCard'?
Replace 'STPPaymentMethodTypeFPX' with 'STPPaymentMethodTypeCard'

Removing this line fixed it.

I'm curious - are you guys still using this library? Are you using something else? are you running into this bug too? Personally I am a bit surprised at the state of the react-native support for stripe, but I haven't found anything else. Do you have any other suggestions?

Thanks!